### PR TITLE
ARM: dts: msm: Early mount of system partition

### DIFF
--- a/arch/arm/boot/dts/qcom/zc550kl_msm8916.dtsi
+++ b/arch/arm/boot/dts/qcom/zc550kl_msm8916.dtsi
@@ -27,6 +27,23 @@
 	chosen {
 		bootargs = "sched_enable_hmp=1";
 	};
+	
+	firmware: firmware {
+		android {
+			compatible = "android,firmware";
+			fstab {
+				compatible = "android,fstab";
+				system {
+					compatible = "android,system";
+					dev = "/dev/block/platform/soc.0/7824900.sdhci/by-name/system";
+					type = "ext4";
+					mnt_flags = "ro,barrier=1,discard";
+					fsmgr_flags = "wait";
+					status = "ok";
+				};
+			};
+		};
+	};
 
 	aliases {
 		sdhc1 = &sdhc_1; /* SDC1 eMMC slot */

--- a/arch/arm/boot/dts/qcom/ze500kg-er1_msm8916.dtsi
+++ b/arch/arm/boot/dts/qcom/ze500kg-er1_msm8916.dtsi
@@ -28,6 +28,23 @@
 		bootargs = "sched_enable_hmp=1";
 	};
 
+	firmware: firmware {
+		android {
+			compatible = "android,firmware";
+			fstab {
+				compatible = "android,fstab";
+				system {
+					compatible = "android,system";
+					dev = "/dev/block/platform/soc.0/7824900.sdhci/by-name/system";
+					type = "ext4";
+					mnt_flags = "ro,barrier=1,discard";
+					fsmgr_flags = "wait";
+					status = "ok";
+				};
+			};
+		};
+	};
+
 	aliases {
 		sdhc1 = &sdhc_1; /* SDC1 eMMC slot */
 		sdhc2 = &sdhc_2; /* SDC2 SD card slot */

--- a/arch/arm/boot/dts/qcom/ze500kg-pr_msm8916.dtsi
+++ b/arch/arm/boot/dts/qcom/ze500kg-pr_msm8916.dtsi
@@ -28,6 +28,40 @@
 		bootargs = "sched_enable_hmp=1";
 	};
 
+	firmware: firmware {
+		android {
+			compatible = "android,firmware";
+			fstab {
+				compatible = "android,fstab";
+				system {
+					compatible = "android,system";
+					dev = "/dev/block/platform/soc.0/7824900.sdhci/by-name/system";
+					type = "ext4";
+					mnt_flags = "ro,barrier=1,discard";
+					fsmgr_flags = "wait";
+					status = "ok";
+				};
+			};
+		};
+	};
+
+	firmware: firmware {
+		android {
+			compatible = "android,firmware";
+			fstab {
+				compatible = "android,fstab";
+				system {
+					compatible = "android,system";
+					dev = "/dev/block/platform/soc.0/7824900.sdhci/by-name/system";
+					type = "ext4";
+					mnt_flags = "ro,barrier=1,discard";
+					fsmgr_flags = "wait";
+					status = "ok";
+				};
+			};
+		};
+	};
+
 	aliases {
 		sdhc1 = &sdhc_1; /* SDC1 eMMC slot */
 		sdhc2 = &sdhc_2; /* SDC2 SD card slot */

--- a/arch/arm/boot/dts/qcom/ze500kg-sr1_msm8916.dtsi
+++ b/arch/arm/boot/dts/qcom/ze500kg-sr1_msm8916.dtsi
@@ -28,6 +28,23 @@
 		bootargs = "sched_enable_hmp=1";
 	};
 
+	firmware: firmware {
+		android {
+			compatible = "android,firmware";
+			fstab {
+				compatible = "android,fstab";
+				system {
+					compatible = "android,system";
+					dev = "/dev/block/platform/soc.0/7824900.sdhci/by-name/system";
+					type = "ext4";
+					mnt_flags = "ro,barrier=1,discard";
+					fsmgr_flags = "wait";
+					status = "ok";
+				};
+			};
+		};
+	};
+
 	aliases {
 		sdhc1 = &sdhc_1; /* SDC1 eMMC slot */
 		sdhc2 = &sdhc_2; /* SDC2 SD card slot */

--- a/arch/arm/boot/dts/qcom/ze500kl-pr_msm8916.dtsi
+++ b/arch/arm/boot/dts/qcom/ze500kl-pr_msm8916.dtsi
@@ -28,6 +28,24 @@
 		bootargs = "sched_enable_hmp=1";
 	};
 
+	firmware: firmware {
+		android {
+			compatible = "android,firmware";
+			fstab {
+				compatible = "android,fstab";
+				system {
+					compatible = "android,system";
+					dev = "/dev/block/platform/soc.0/7824900.sdhci/by-name/system";
+					type = "ext4";
+					mnt_flags = "ro,barrier=1,discard";
+					fsmgr_flags = "wait";
+					status = "ok";
+				};
+			};
+		};
+	};
+
+
 	aliases {
 		sdhc1 = &sdhc_1; /* SDC1 eMMC slot */
 		sdhc2 = &sdhc_2; /* SDC2 SD card slot */

--- a/arch/arm/boot/dts/qcom/ze500kl-sr1_msm8916.dtsi
+++ b/arch/arm/boot/dts/qcom/ze500kl-sr1_msm8916.dtsi
@@ -28,6 +28,23 @@
 		bootargs = "sched_enable_hmp=1";
 	};
 
+	firmware: firmware {
+		android {
+			compatible = "android,firmware";
+			fstab {
+				compatible = "android,fstab";
+				system {
+					compatible = "android,system";
+					dev = "/dev/block/platform/soc.0/7824900.sdhci/by-name/system";
+					type = "ext4";
+					mnt_flags = "ro,barrier=1,discard";
+					fsmgr_flags = "wait";
+					status = "ok";
+				};
+			};
+		};
+	};
+
 	aliases {
 		sdhc1 = &sdhc_1; /* SDC1 eMMC slot */
 		sdhc2 = &sdhc_2; /* SDC2 SD card slot */


### PR DESCRIPTION
Add support to early mount system partition so that system modules
can be loaded during early init.

Change-Id: Ib9a3e5dca8923a900f76b276ed05b34f45a84063
Signed-off-by: Swetha Chikkaboraiah <schikk@codeaurora.org>